### PR TITLE
Setting Build Materials in product items as category and here …

### DIFF
--- a/assets/api-data/product-hierarchy.json
+++ b/assets/api-data/product-hierarchy.json
@@ -42,7 +42,7 @@
         "Bags",
         "Wallet"
     ],
-    "Materials": [
+    "Build Materials": [
         "Blocks/Bricks",
         "Timber",
         "Plumbing",


### PR DESCRIPTION
…we are setting just Materials

This causes an issue while retrieving hierarchy
We are setting Build Materials in product items as category and here we are setting just Materials
@AnirupPat I will be reverting your change